### PR TITLE
.gitignoreファイルを新規に作成し、追加しました。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*DS_Store
+*password.log
+*password.asc


### PR DESCRIPTION
.gitignoreファイルを追加しました。
以下のファイルがgitの対象から外れます。
DS_Store (Macが自動生成するファイル)
password.log (パスワードマネージャが作成するパスワードが保存されたファイル)
password.asc (暗号化機能対応版パスワードマネージャが作成する暗号化されたパスワードが保存されたファイル)